### PR TITLE
test-integration on Azure Pipelines

### DIFF
--- a/.azure-pipelines/jobs/dev-integration-test.yml
+++ b/.azure-pipelines/jobs/dev-integration-test.yml
@@ -1,0 +1,9 @@
+steps:
+  - template: ../steps/install-nodejs.yml
+  - template: ../steps/install-dependencies.yml
+    parameters:
+      flags: --ignore-engines # needed for yarn install to succeed on Node.js 6
+  - script: yarn test-integration
+    displayName: "Run tests"
+  - template: ../steps/publish-test-results.yml
+  - template: ../steps/publish-code-coverage.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,19 @@ jobs:
     steps:
       - template: .azure-pipelines/jobs/dev-test.yml
 
+  - job: Dev_Integration_Test_Linux
+    displayName: Dev integration Test on Linux
+    pool:
+      vmImage: "Ubuntu 16.04"
+    strategy:
+      matrix:
+        Node_v6:
+          node_version: 6
+        Node_v10:
+          node_version: 10
+    steps:
+      - template: .azure-pipelines/jobs/dev-integration-test.yml
+
   - job: Prod_Build
     displayName: Prod Build on Linux Node v10
     pool:


### PR DESCRIPTION
on Node.js versions 6 & 10

in order to avoid mistakes such as get-stream@5 update, which breaks installation from GitHub on Node.js version 6

I already checked that the Azure Pipelines build with this proposed change is green.

- [x] I’ve added tests to confirm my change works.
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).