### PR TITLE
[WIP] TEST get-stream@5 with test-integration on Azure Pipelines - EXPERIMENTAL WIP with KNOWN FAILURE

### DIFF
--- a/.azure-pipelines/jobs/dev-integration-test.yml
+++ b/.azure-pipelines/jobs/dev-integration-test.yml
@@ -1,0 +1,9 @@
+steps:
+  - template: ../steps/install-nodejs.yml
+  - template: ../steps/install-dependencies.yml
+    parameters:
+      flags: --ignore-engines # needed for yarn install to succeed on Node.js 6
+  - script: yarn test-integration
+    displayName: "Run tests"
+  - template: ../steps/publish-test-results.yml
+  - template: ../steps/publish-code-coverage.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,19 @@ jobs:
     steps:
       - template: .azure-pipelines/jobs/dev-test.yml
 
+  - job: Dev_Integration_Test_Linux
+    displayName: Dev integration Test on Linux
+    pool:
+      vmImage: "Ubuntu 16.04"
+    strategy:
+      matrix:
+        Node_v6:
+          node_version: 6
+        Node_v10:
+          node_version: 10
+    steps:
+      - template: .azure-pipelines/jobs/dev-integration-test.yml
+
   - job: Prod_Build
     displayName: Prod Build on Linux Node v10
     pool:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "find-parent-dir": "0.3.0",
     "find-project-root": "1.1.1",
     "flow-parser": "0.84.0",
-    "get-stream": "3.0.0",
+    "get-stream": "5.1.0",
     "globby": "6.1.0",
     "graphql": "14.2.0",
     "html-element-attributes": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,13 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
 enhanced-resolve@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
@@ -2923,7 +2930,14 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
-get-stream@3.0.0, get-stream@^3.0.0:
+get-stream@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
@@ -4956,7 +4970,7 @@ octal@^1.0.0:
   resolved "https://registry.yarnpkg.com/octal/-/octal-1.0.0.tgz#63e7162a68efbeb9e213588d58e989d1e5c4530b"
   integrity sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws=
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -5387,6 +5401,14 @@ public-encrypt@^4.0.0:
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Try get-stream@5.1.0 update along with `test-integration` on Azure Pipelines (see PR #1).

This is EXPECTED TO FAIL with `test-integration` on Node.js version 6.

This PR validates that my proposal to add `test-integration` on Azure Pipelines (#1) catches this kind of a regression.