### PR TITLE
Dev test on Linux Node.js 6, 8, and 12

### DIFF
--- a/.azure-pipelines/jobs/dev-test.yml
+++ b/.azure-pipelines/jobs/dev-test.yml
@@ -1,6 +1,8 @@
 steps:
   - template: ../steps/install-nodejs.yml
   - template: ../steps/install-dependencies.yml
+    parameters:
+      flags: --ignore-engines # needed for yarn install to succeed on Node.js 6
   - script: yarn test
     displayName: "Run tests"
   - template: ../steps/publish-test-results.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,11 +38,19 @@ jobs:
       - template: .azure-pipelines/jobs/dev-test.yml
 
   - job: Dev_Test_Linux
-    displayName: Dev Test on Linux Node v10
+    displayName: Dev Test on Linux
     pool:
       vmImage: "Ubuntu 16.04"
-    variables:
-      node_version: 10
+    strategy:
+      matrix:
+        Node_v6:
+          node_version: 6
+        Node_v8:
+          node_version: 8
+        Node_v10:
+          node_version: 10
+        Node_v12:
+          node_version: 12
     steps:
       - template: .azure-pipelines/jobs/dev-test.yml
 


### PR DESCRIPTION
using the `--ignore-engines` flag on Yarn, as needed on Node.js 6

in order to avoid mistakes such as get-stream@5 update, which breaks installation from GitHub on Node.js version 6

NOTE: This proposal is known to fail on Node.js version 6 due to a seg fault. I can think of the following possible workarounds:

- just do `test-integration` on Node.js 6, like I proposed in #1;
- look for a way to do `yarn test` with Jest in smaller parts